### PR TITLE
XML Support

### DIFF
--- a/src/Mordilion/Configurable/Configuration/Factory.php
+++ b/src/Mordilion/Configurable/Configuration/Factory.php
@@ -16,6 +16,7 @@ use Mordilion\Configurable\Configuration\Reader\ReaderInterface;
 use Mordilion\Configurable\Configuration\Reader\Ini;
 use Mordilion\Configurable\Configuration\Reader\Json;
 use Mordilion\Configurable\Configuration\Reader\Yaml;
+use Mordilion\Configurable\Configuration\Reader\Xml;
 
 /**
  * Mordilion\Configurable Factory-Class.
@@ -34,6 +35,7 @@ class Factory
         'json' => 'Json',
         'yml'  => 'Yaml',
         'yaml' => 'Yaml',
+        'xml'  => 'Xml'
     );
 
 

--- a/src/Mordilion/Configurable/Configuration/Reader/Decoder/DecoderInterface.php
+++ b/src/Mordilion/Configurable/Configuration/Reader/Decoder/DecoderInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the Mordilion\Configurable package.
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ *
+ * @copyright (c) Henning Huncke - <mordilion@gmx.de>
+ */
+
+namespace Mordilion\Configurable\Configuration\Reader\Decoder;
+
+/**
+ * Mordilion\Configurable Decoder-Interface.
+ *
+ * @author Frederik Wauters <frederik.wauters@web.de>
+ */
+interface DecoderInterface
+{
+    /**
+     * Decodes provided string information into array
+     *
+     * @param string $string
+     *
+     * @return array|false
+     */
+    public function decode($string);
+}

--- a/src/Mordilion/Configurable/Configuration/Reader/Decoder/SimpleXml.php
+++ b/src/Mordilion/Configurable/Configuration/Reader/Decoder/SimpleXml.php
@@ -28,16 +28,36 @@ class SimpleXml implements DecoderInterface
      */
     public function decode($xml)
     {
-        $data = (array) simplexml_load_string($xml);
+        return $this->castToArray((array) simplexml_load_string($xml));
+    }
 
-        // Recursively cast to array
-        array_walk_recursive($data, function(&$item) {
-            if($item instanceof \SimpleXMLElement){
-                $item = (array) $item;
+    /**
+     * Recursively cast to array
+     *
+     * @param  mixed $input
+     * @return array
+     */
+    private function castToArray($input)
+    {
+        $result = array();
+
+        foreach($input as $key => $value){
+            if($value instanceof \SimpleXMLElement){
+                $result[$key] = $this->castToArray((array) $value);
+            }elseif(is_array($value)){
+                $result[$key] = $this->castToArray($value);
+            }else{
+                if(is_numeric($value)){
+                    $result[$key] = $value + 0;
+                }elseif($value == "true" || $value == "false"){
+                    $result[$key] = filter_var($value, FILTER_VALIDATE_BOOLEAN);
+                }else{
+                    $result[$key] = $value;
+                }
             }
-        });        
+        }       
 
-        return $data;
+        return $result;
     }
 }
 

--- a/src/Mordilion/Configurable/Configuration/Reader/Decoder/SimpleXml.php
+++ b/src/Mordilion/Configurable/Configuration/Reader/Decoder/SimpleXml.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of the Mordilion\Configurable package.
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ *
+ * @copyright (c) Henning Huncke - <mordilion@gmx.de>
+ */
+
+namespace Mordilion\Configurable\Configuration\Reader\Decoder;
+
+use Mordilion\Configurable\Configuration\Reader\Decoder\DecoderInterface;
+
+/**
+ * Mordilion\Configurable Decoder class.
+ *
+ * @author Frederik Wauters <frederik.wauters@web.de>
+ */
+class SimpleXml implements DecoderInterface
+{
+    /**
+     * Simple XML decoder
+     *
+     * @param  string $xml
+     * @return array  $conf
+     */
+    public function decode($xml)
+    {
+        $data = (array) simplexml_load_string($xml);
+
+        // Recursively cast to array
+        array_walk_recursive($data, function(&$item) {
+            if($item instanceof \SimpleXMLElement){
+                $item = (array) $item;
+            }
+        });        
+
+        return $data;
+    }
+}
+

--- a/src/Mordilion/Configurable/Configuration/Reader/Xml.php
+++ b/src/Mordilion/Configurable/Configuration/Reader/Xml.php
@@ -1,0 +1,186 @@
+<?php
+
+/**
+ * This file is part of the Mordilion\Configurable package.
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ *
+ * @copyright (c) Henning Huncke - <mordilion@gmx.de>
+ */
+
+namespace Mordilion\Configurable\Configuration\Reader;
+
+use Mordilion\Configurable\Configuration\Reader\Decoder\SimpleXml;
+
+/**
+ * Mordilion\Configurable Xml-Class.
+ *
+ * @author Frederik Wauters <frederik.wauters@web.de>
+ */
+class Xml implements ReaderInterface
+{
+    /**
+     * Callable to decode the XML string in an array.
+     *
+     * @var callable
+     */
+    private $decoder;
+
+    /**
+     * Decoder params 
+     *
+     * @var array $params
+     */
+    private $decoderParams = array();
+
+    /**
+     * Constructor.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        if(class_exists('Symfony\Component\Serializer\Serializer')
+            && class_exists('Symfony\Component\Serializer\Encoder\XmlEncoder')
+            && class_exists('Symfony\Component\Serializer\Normalizer\ObjectNormalizer')
+        ){
+            // Load from fully qualified Namespace (No use in case not installed) 
+            $serializer = new \Symfony\Component\Serializer\Serializer(
+                array(new \Symfony\Component\Serializer\Normalizer\ObjectNormalizer()),
+                array(new \Symfony\Component\Serializer\Encoder\XmlEncoder())
+            ); 
+
+            // Set Symfony/Serializer as decoder, which takes format as parameter
+            $this->setDecoder(array($serializer, 'decode'))
+                 ->setDecoderParams(array('xml'));
+
+        }elseif(function_exists('simplexml_load_string')){
+            // Set simplexml_load_string as decoder, which don't need parameters
+            $this->setDecoder(array(new SimpleXml(), 'decode'));
+            
+        }
+    }
+
+    /**
+     * Returns the current decoder.
+     *
+     * @return callable
+     */
+    public function getDecoder()
+    {
+        return $this->decoder;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadFile($filename)
+    {
+        if (!is_file($filename)) {
+            throw new \InvalidArgumentException('The provided filename is not a valid filename.');
+        }
+
+        if (!is_readable($filename)) {
+            throw new \RuntimeException('The file "' . $filename . '" is not readable.');
+        }
+
+        $content = file_get_contents($filename);
+
+        return $this->loadString($content);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadString($string)
+    {
+        if (empty($string)) {
+            return array();
+        }
+
+        return $this->decode($string);
+    }
+
+    /**
+     * Sets the decoder.
+     *
+     * @param callable $decoder
+     *
+     * @return Xml
+     */
+    public function setDecoder($decoder)
+    {
+        if (!is_callable($decoder)) {
+            throw new \InvalidArgumentException('The provided decoder must be callable.');
+        }
+
+        $this->decoder = $decoder;
+
+        return $this;
+    }
+
+    /**
+     * Sets decoder call params
+     *
+     * @param  array $params
+     */
+    public function setDecoderParams(array $params)
+    {
+        $this->decoderParams = $params;
+
+        return $this;
+    }
+
+    /**
+     * Returns decoder params
+     *
+     * @return array $decoderParams
+     */
+    public function getDecoderParams()
+    {
+        return $this->decoderParams;
+    }
+
+
+    /**
+     * Decodes the provided $xml into an object or an array.
+     *
+     * @param string $xml
+     *
+     * @throws \RuntimeException if a decoder is not specified
+     * @throws \RuntimeException if the provided xml is not valid
+     * @throws \RuntimeException if a exception was catched
+     * @throws \RuntimeException if the decoding throwed some errors
+     *
+     * @return array
+     */
+    private function decode($xml)
+    {
+        try {
+            $decoder = $this->getDecoder();
+
+            if ($decoder === null) {
+                throw new \RuntimeException('You didn\'t specify a decoder.');
+            }
+
+            $data = call_user_func_array($decoder, array_merge(
+                array($xml), 
+                $this->getDecoderParams()
+            ));
+
+            if (!is_array($data) && !is_object($data)) {
+                throw new \RuntimeException('The provided XML is not valid.');
+            }
+
+            if ($data !== false) {
+                return $data;
+            }
+        } catch (Exception $e) {
+            throw new \RuntimeException('Unable to parse the XML string! :: ' . $e->getMessage());
+        }
+
+        // Todo: check if valid XML
+        throw new \RuntimeException('Unable to parse the XML string!');
+    }
+}

--- a/tests/Data/test.xml
+++ b/tests/Data/test.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root>
+  <var1>This is a text</var1>
+  <var2>123456789</var2>
+  <var3>true</var3>
+  <var4>
+    <var4.1>Another text</var4.1>
+    <var4.2>12345</var4.2>
+    <var4.3>false</var4.3>
+  </var4>
+  <fruits>Apple</fruits>
+  <fruits>Orange</fruits>
+  <fruits>Mango</fruits>
+</root>

--- a/tests/Mordilion/Configurable/Configuration/Reader/XmlTest.php
+++ b/tests/Mordilion/Configurable/Configuration/Reader/XmlTest.php
@@ -1,0 +1,103 @@
+<?php
+
+require_once 'Mordilion/Configurable/Configuration/ConfigurationInterface.php';
+require_once 'Mordilion/Configurable/Configuration/Configuration.php';
+require_once 'Mordilion/Configurable/Configuration/Reader/ReaderInterface.php';
+require_once 'Mordilion/Configurable/Configuration/Reader/Xml.php';
+
+use PHPUnit\Framework\TestCase;
+
+use Mordilion\Configurable\Configurable;
+use Mordilion\Configurable\Configuration\Configuration;
+use Mordilion\Configurable\Configuration\Reader\Xml;
+
+class XmlTest extends TestCase
+{
+    /**
+     * @dataProvider getXmlData
+     */
+    public function testXmlLoadStringWithValidXmlString($xml)
+    {
+        $reader = new Xml();
+
+        $configuration = new Configuration($reader->loadString($xml));
+
+        $configurationArray = $configuration->toArray();
+
+        $this->assertInstanceOf(Configuration::class, $configuration);
+        $this->assertArrayHasKey('var1', $configurationArray);
+        $this->assertArrayHasKey('var2', $configurationArray);
+        $this->assertArrayHasKey('var3', $configurationArray);
+        $this->assertArrayHasKey('var4', $configurationArray);
+        $this->assertArrayHasKey('fruits', $configurationArray);
+        $this->assertEquals($configurationArray['var1'], 'This is a text');
+        $this->assertEquals($configurationArray['var2'], '123456789');
+        $this->assertEquals($configurationArray['var3'], "true");
+        $this->assertEquals($configurationArray['var4']['var4.1'], 'Another text');
+        $this->assertEquals($configurationArray['var4']['var4.2'], '12345');
+        $this->assertEquals($configurationArray['var4']['var4.3'], 'false');
+        $this->assertEquals($configurationArray['fruits'][0], 'Apple');
+        $this->assertEquals($configurationArray['fruits'][1], 'Orange');
+        $this->assertEquals($configurationArray['fruits'][2], 'Mango');
+
+    }
+
+    public function testLoadFileMethodThrowsInvalidArgumentExceptionForNotExistingFile()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $reader = new Xml();
+
+        $reader->loadFile('not-existing-file.xml');
+    }
+
+    public function testLoadStringMethodReturnsAnEmptyArraForEmptyString()
+    {
+        $reader = new Xml();
+
+        $this->assertEquals($reader->loadString(''), array());
+        $this->assertEquals($reader->loadString(null), array());
+        $this->assertEquals($reader->loadString(false), array());
+    }
+
+    public function testSetDecoderMethodThrowsInvalidArgumentExceptionIfDecoderIsNotCallable()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $reader = new Xml();
+
+        $reader->setDecoder('Whatever!');
+    }
+
+    public function testDecodeMethodThrowsRuntimeExceptionIfNoDecoderIsSet()
+    {
+        $this->expectException(\RuntimeException::class);
+
+        $reader = new Xml();
+
+        $reflection = new ReflectionClass($reader);
+        $reflectionProperty = $reflection->getProperty('decoder');
+        $reflectionProperty->setAccessible(true);
+
+        $reflectionProperty->setValue($reader, null);
+
+        $reader->loadString('Whatever!');
+    }
+
+    public function getXmlData()
+    {
+        $xml = file_get_contents(
+            dirname(__FILE__) . DIRECTORY_SEPARATOR .
+            '..'   . DIRECTORY_SEPARATOR .
+            '..'   . DIRECTORY_SEPARATOR .
+            '..'   . DIRECTORY_SEPARATOR .
+            '..'   . DIRECTORY_SEPARATOR .
+            'Data' . DIRECTORY_SEPARATOR .
+            'test.xml'
+        );
+
+        return array(
+            'valid'   => array($xml),
+        );
+    }
+}

--- a/tests/Mordilion/Configurable/Configuration/Reader/XmlTest.php
+++ b/tests/Mordilion/Configurable/Configuration/Reader/XmlTest.php
@@ -1,10 +1,5 @@
 <?php
 
-require_once 'Mordilion/Configurable/Configuration/ConfigurationInterface.php';
-require_once 'Mordilion/Configurable/Configuration/Configuration.php';
-require_once 'Mordilion/Configurable/Configuration/Reader/ReaderInterface.php';
-require_once 'Mordilion/Configurable/Configuration/Reader/Xml.php';
-
 use PHPUnit\Framework\TestCase;
 
 use Mordilion\Configurable\Configurable;
@@ -67,6 +62,23 @@ class XmlTest extends TestCase
         $reader = new Xml();
 
         $reader->setDecoder('Whatever!');
+    }
+
+    public function testReturnObjectOnSettingDecoderParams()
+    {
+        $reader = new XML();
+        $object = $reader->setDecoderParams(array('test'));
+
+        $this->assertInstanceOf(Xml::class, $object);
+    }
+
+    public function testGetDecoderParamsReturnsArray()
+    {
+        $reader = new XML();
+        $array  = $reader->setDecoderParams(array('test' => 'test'))
+                         ->getDecoderParams();
+
+        $this->assertInternalType('array', $array);
     }
 
     public function testDecodeMethodThrowsRuntimeExceptionIfNoDecoderIsSet()

--- a/tests/Mordilion/Configurable/Configuration/Reader/XmlTest.php
+++ b/tests/Mordilion/Configurable/Configuration/Reader/XmlTest.php
@@ -31,11 +31,11 @@ class XmlTest extends TestCase
         $this->assertArrayHasKey('var4', $configurationArray);
         $this->assertArrayHasKey('fruits', $configurationArray);
         $this->assertEquals($configurationArray['var1'], 'This is a text');
-        $this->assertEquals($configurationArray['var2'], '123456789');
-        $this->assertEquals($configurationArray['var3'], "true");
+        $this->assertEquals($configurationArray['var2'], 123456789);
+        $this->assertEquals($configurationArray['var3'], true);
         $this->assertEquals($configurationArray['var4']['var4.1'], 'Another text');
-        $this->assertEquals($configurationArray['var4']['var4.2'], '12345');
-        $this->assertEquals($configurationArray['var4']['var4.3'], 'false');
+        $this->assertEquals($configurationArray['var4']['var4.2'], 12345);
+        $this->assertEquals($configurationArray['var4']['var4.3'], false);
         $this->assertEquals($configurationArray['fruits'][0], 'Apple');
         $this->assertEquals($configurationArray['fruits'][1], 'Orange');
         $this->assertEquals($configurationArray['fruits'][2], 'Mango');


### PR DESCRIPTION
The XML reader itself is first of all looking for Symfony's Serializer component and uses its XmlEncoder to transform the XML to an array.
If this is not found the fallback is `simplexml_load_string`

Since simply calling the simplexml method, didn't seem to quite cut it, I have added a Decoder component for this in `Mordilion\Configurable\Configuration\Reader\Decoder\Xml`.
Basically additional "custom" decoders can be defined implementing the interface in `Mordilion\Configurable\Configuration\Reader\Decoder\DecoderInterface`

Issue: #3